### PR TITLE
Add node_ip to configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -217,6 +217,10 @@ livekit_server_config_rtc_udp_port: 7882
 # This is useful for cloud environments such as AWS & Google where hosts have an internal IP that maps to an external one.
 livekit_server_config_rtc_use_external_ip: true
 
+# Controls the `rtc.node_ip` configuration proberty
+# This is the rtc IP address sent to the client.
+livekit_server_config_rtc_node_ip: ''
+
 ########################################################################################
 #                                                                                      #
 # /RTC                                                                                 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -215,10 +215,13 @@ livekit_server_config_rtc_udp_port: 7882
 # Controls the `rtc.use_external_ip` configuration property.
 # When set to true, attempts to discover the host's public IP via STUN.
 # This is useful for cloud environments such as AWS & Google where hosts have an internal IP that maps to an external one.
+# Related to: `livekit_server_config_rtc_node_ip`
 livekit_server_config_rtc_use_external_ip: true
 
-# Controls the `rtc.node_ip` configuration proberty
-# This is the rtc IP address sent to the client.
+# Controls the `rtc.node_ip` configuration property.
+# This is the IP address sent to the client in case you cannot rely on external IP auto-detection.
+# Related to `livekit_server_config_rtc_use_external_ip`
+# See: https://github.com/livekit/livekit/issues/3747
 livekit_server_config_rtc_node_ip: ''
 
 ########################################################################################

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -22,7 +22,7 @@ rtc:
   use_external_ip: {{ livekit_server_config_rtc_use_external_ip | to_json }}
 
   {% if livekit_server_config_rtc_node_ip %}
-  node_ip: {{ livekit_server_config_rtc_node_ip | to_json}}
+  node_ip: {{ livekit_server_config_rtc_node_ip | to_json }}
   {% endif %}
 
 turn:

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -21,6 +21,10 @@ rtc:
 
   use_external_ip: {{ livekit_server_config_rtc_use_external_ip | to_json }}
 
+  {% if livekit_server_config_rtc_node_ip %}
+  node_ip: {{ livekit_server_config_rtc_node_ip | to_json}}
+  {% endif %}
+
 turn:
   enabled: {{ livekit_server_config_turn_enabled | to_json }}
 {% if livekit_server_config_turn_enabled %}


### PR DESCRIPTION
This is needed to change the IP address sent to the clients. 

My need for this was because I'm deploying it in an offline environment, and, when combined with the `use_external_ip` disabled, it sends out the Docker IP address to the client. 

related issue
https://github.com/livekit/livekit/issues/3747